### PR TITLE
Fix failed VIES calls since Oct 28th 2021

### DIFF
--- a/lib/vat_check/requests.rb
+++ b/lib/vat_check/requests.rb
@@ -6,7 +6,7 @@ class VatCheck
       client = Savon.client(wsdl: 'https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl', follow_redirects: true, log: false, log_level: :debug, pretty_print_xml: false)
       country_code, vat_number = VatCheck::Utility.split(vat)
       begin
-        response = client.call(:check_vat, message: {country_code: country_code, vat_number: vat_number}, message_tag: :checkVat)
+        response = client.call(:check_vat, message: {country_code: country_code, vat_number: vat_number}, message_tag: :checkVat, soap_action: nil)
         response.to_hash[:check_vat_response].reject { |key| key == :@xmlns }
       rescue Savon::SOAPFault => e
         if !!(e.message =~ /MS_UNAVAILABLE/)


### PR DESCRIPTION
VIES calls started failing with this gem around October 28th. We traced
the issue back to the SOAPAction key being included in the request
header. Here is a quick fix to exclude the offending header.

For search purposes, the error we got was:
"Unknown error: (soap:Server) The given SOAPAction checkVat does not match an operation."

Before this fix:

```
>> VatCheck.new('LU20260743')
=> #<VatCheck:0x00007f8b98a09828 @vat="LU20260743", @regex=true, @response={:error=>"Unknown error: (soap:Server) The given SOAPAction checkVat does not match an operation."}, @vies_available=false, @vies=false>

```

After the fix:

```
>> VatCheck.new('LU20260743')
=> #<VatCheck:0x00007fc6fdabeca0 @vat="LU20260743", @regex=true, @response={:country_code=>"LU", :vat_number=>"20260743", :request_date=>Mon, 01 Nov 2021, :valid=>true, :name=>"AMAZON EU SARL", :address=>"38, AVENUE JOHN F. KENNEDY\nL-1855  LUXEMBOURG"}, @vies_available=true, @vies=true>
```